### PR TITLE
Make a proper multi-arch build

### DIFF
--- a/com.valvesoftware.Steam.Utility.MumbleOverlay.yaml
+++ b/com.valvesoftware.Steam.Utility.MumbleOverlay.yaml
@@ -8,30 +8,57 @@ runtime: com.valvesoftware.Steam
 runtime-version: stable
 build-extension: true
 appstream-compose: false
+build-options:
+  prefix: /app/utils/MumbleOverlay
+  prepend-path: /app/utils/MumbleOverlay/bin
+  prepend-pkg-config-path: /app/utils/MumbleOverlay/lib/pkgconfig
+x-arch-build-options:
+  x86_64: &x86_64-build-options
+    libdir: /app/utils/MumbleOverlay/lib/x86_64-linux-gnu
+    prepend-pkg-config-path: /app/utils/MumbleOverlay/lib/x86_64-linux-gnu/pkgconfig
+  i386: &i386-build-options
+    libdir: /app/utils/MumbleOverlay/lib/i386-linux-gnu
+    prepend-pkg-config-path: /app/utils/MumbleOverlay/lib/i386-linux-gnu/pkgconfig
+    append-path: /usr/lib/sdk/toolchain-i386/bin
+    env:
+      CC: i686-unknown-linux-gnu-gcc
+      CXX: i686-unknown-linux-gnu-g++
+cleanup:
+  - /include
+  - /lib/*.a
+  - /lib/*.la
+  - /lib/pkgconfig
+  - /lib/cmake
 modules:
   - name: mumble-overlay
-    buildsystem: cmake
-    build-options: &compat-i386-build-options
-      prepend-pkg-config-path: /app/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig
-      ldflags: -L/app/lib32/
-      prepend-path: /usr/lib/sdk/toolchain-i386/bin
-      env:
-        CC: i686-unknown-linux-gnu-gcc
-        CXX: i686-unknown-linux-gnu-g++
-    config-opts:
-      - -DCMAKE_INSTALL_PREFIX=${FLATPAK_DEST}
+    buildsystem: cmake-ninja
+    builddir: true
+    build-options:
+      arch:
+        x86_64: *x86_64-build-options
+    config-opts: &mumble-overlay-config-opts
       - -Dserver=OFF
       - -Dclient=OFF
       - -Doverlay=ON
-      - -Doverlay-xcompile=ON
-      - -DBUILD_OVERLAY_XCOMPILE=ON
+      - -Doverlay-xcompile=OFF
+      - -DBUILD_OVERLAY_XCOMPILE=OFF
       - -Dplugins=OFF
-    post-install:
-      - install -Dm644 libmumbleoverlay.x86_64.so.1.5.0 ${FLATPAK_DEST}/lib/libmumbleoverlay.so.1.5.0
-      - ln -s ${FLATPAK_DEST}/lib/libmumbleoverlay.so.1.5.0 ${FLATPAK_DEST}/lib/libmumbleoverlay.so
-      - install -Dm644 libmumbleoverlay.x86.so.1.5.0 ${FLATPAK_DEST}/lib32/libmumbleoverlay.so.1.5.0
-      - ln -s ${FLATPAK_DEST}/lib32/libmumbleoverlay.so.1.5.0 ${FLATPAK_DEST}/lib32/libmumbleoverlay.so
-    sources:
+    sources: &mumble-overlay-sources
       - type: git
-        url: https://github.com/carlocastoldi/mumble
-        commit: "d904783ecdf37944a9df81518c9c303adf616ca8"
+        url: https://github.com/mumble-voip/mumble.git
+        tag: v1.4.287
+        commit: 5d808e287e99b402b724e411a7a0848e00956a24
+      - type: patch
+        paths:
+          - patches/mumble/0001-BUILD-crypto-Migrate-to-OpenSSL-3.0-compatible-API.patch
+          - patches/mumble/0001-BUILD-overlay-build-overlay-on-Linux-and-FreeBSD-wit.patch
+          - patches/mumble/0001-CHANGE-ipc-move-Socket-and-OverlayPipe-to-XDG_RUNTIM.patch
+
+  - name: mumble-overlay-32bit
+    buildsystem: cmake-ninja
+    builddir: true
+    build-options:
+      arch:
+        x86_64: *i386-build-options
+    config-opts: *mumble-overlay-config-opts
+    sources: *mumble-overlay-sources

--- a/com.valvesoftware.Steam.Utility.MumbleOverlay.yaml
+++ b/com.valvesoftware.Steam.Utility.MumbleOverlay.yaml
@@ -53,6 +53,7 @@ modules:
           - patches/mumble/0001-BUILD-crypto-Migrate-to-OpenSSL-3.0-compatible-API.patch
           - patches/mumble/0001-BUILD-overlay-build-overlay-on-Linux-and-FreeBSD-wit.patch
           - patches/mumble/0001-CHANGE-ipc-move-Socket-and-OverlayPipe-to-XDG_RUNTIM.patch
+          - patches/mumble/0001-FIX-overlay-Implement-library-search-list-for-dlsym-.patch
 
   - name: mumble-overlay-32bit
     buildsystem: cmake-ninja

--- a/patches/mumble/0001-BUILD-crypto-Migrate-to-OpenSSL-3.0-compatible-API.patch
+++ b/patches/mumble/0001-BUILD-crypto-Migrate-to-OpenSSL-3.0-compatible-API.patch
@@ -1,0 +1,555 @@
+From 639012d036a2b1224e874c72e3edaa2ac6598c5d Mon Sep 17 00:00:00 2001
+From: Terry Geng <terry@terriex.com>
+Date: Mon, 6 Dec 2021 10:45:11 -0500
+Subject: [PATCH 1/4] BUILD(crypto): Migrate to OpenSSL 3.0-compatible API
+
+OpenSSL 3.0 deprecated several low-level APIs and the usage of them
+caused errors/warnings that prevent the binary from being built against
+OpenSSL 3.0.
+Some primitive efforts have been made in #5317 but were incomplete.
+This commit follows https://www.openssl.org/docs/man3.0/man7/migration_guide.html,
+https://code.woboq.org/qt6/qtopcua/src/opcua/x509/qopcuakeypair_openssl.cpp.html,
+and clears all errors/warnings related to the usage of deprecated APIs.
+
+Fixes #5277
+Fixes #4266
+
+(cherry picked from commit f4cea62ed95e4967d8591f25e903f5e8fc2e2a30)
+---
+ src/SelfSignedCertificate.cpp | 235 +++++++++++-----------------------
+ src/SelfSignedCertificate.h   |   5 +
+ src/crypto/CryptStateOCB2.cpp |  53 +++++---
+ src/crypto/CryptStateOCB2.h   |   9 +-
+ 4 files changed, 121 insertions(+), 181 deletions(-)
+
+diff --git a/src/SelfSignedCertificate.cpp b/src/SelfSignedCertificate.cpp
+index a77e5fad9..ea0dec4cc 100644
+--- a/src/SelfSignedCertificate.cpp
++++ b/src/SelfSignedCertificate.cpp
+@@ -5,8 +5,6 @@
+ 
+ #include "SelfSignedCertificate.h"
+ 
+-#include <openssl/x509v3.h>
+-
+ #define SSL_STRING(x) QString::fromLatin1(x).toUtf8().data()
+ 
+ static int add_ext(X509 *crt, int nid, char *value) {
+@@ -28,108 +26,86 @@ static int add_ext(X509 *crt, int nid, char *value) {
+ 	return 1;
+ }
+ 
+-bool SelfSignedCertificate::generate(CertificateType certificateType, QString clientCertName, QString clientCertEmail,
+-									 QSslCertificate &qscCert, QSslKey &qskKey) {
+-	bool ok                    = true;
+-	X509 *x509                 = nullptr;
+-	EVP_PKEY *pkey             = nullptr;
+-	RSA *rsa                   = nullptr;
+-	BIGNUM *e                  = nullptr;
+-	X509_NAME *name            = nullptr;
+-	ASN1_INTEGER *serialNumber = nullptr;
+-	ASN1_TIME *notBefore       = nullptr;
+-	ASN1_TIME *notAfter        = nullptr;
+-	QString commonName;
+-	bool isServerCert = certificateType == CertificateTypeServerCertificate;
+-
+-	if (CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ON) == -1) {
+-		ok = false;
+-		goto out;
++EVP_PKEY *SelfSignedCertificate::generate_rsa_keypair() {
++	EVP_PKEY *pkey = EVP_PKEY_new();
++	if (!pkey) {
++		return nullptr;
+ 	}
+ 
+-	x509 = X509_new();
+-	if (!x509) {
+-		ok = false;
+-		goto out;
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++	EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, nullptr);
++	if (!ctx) {
++		return nullptr;
+ 	}
+-
+-	pkey = EVP_PKEY_new();
+-	if (!pkey) {
+-		ok = false;
+-		goto out;
++	if (EVP_PKEY_keygen_init(ctx) <= 0) {
++		return nullptr;
+ 	}
+-
+-	rsa = RSA_new();
++	if (EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, 2048) <= 0) {
++		return nullptr;
++	}
++	if (EVP_PKEY_keygen(ctx, &pkey) <= 0) {
++		return nullptr;
++	}
++	EVP_PKEY_CTX_free(ctx);
++#else
++	RSA *rsa  = RSA_new();
++	BIGNUM *e = BN_new();
+ 	if (!rsa) {
+-		ok = false;
+-		goto out;
++		return nullptr;
+ 	}
+-
+-	e = BN_new();
+ 	if (!e) {
+-		ok = false;
+-		goto out;
++		return nullptr;
+ 	}
+ 	if (BN_set_word(e, 65537) == 0) {
+-		ok = false;
+-		goto out;
++		return nullptr;
+ 	}
+-
+ 	if (RSA_generate_key_ex(rsa, 2048, e, nullptr) == 0) {
+-		ok = false;
+-		goto out;
++		return nullptr;
+ 	}
+-
+ 	if (EVP_PKEY_assign_RSA(pkey, rsa) == 0) {
+-		ok = false;
+-		goto out;
++		return nullptr;
+ 	}
++	BN_free(e);
++	RSA_free(rsa);
++#endif
++	return pkey;
++}
+ 
+-	if (X509_set_version(x509, 2) == 0) {
+-		ok = false;
+-		goto out;
++#define CHECK(statement) \
++	if (!(statement)) {  \
++		ok = false;      \
++		goto out;        \
+ 	}
+ 
+-	serialNumber = X509_get_serialNumber(x509);
+-	if (!serialNumber) {
+-		ok = false;
+-		goto out;
+-	}
+-	if (ASN1_INTEGER_set(serialNumber, 1) == 0) {
+-		ok = false;
+-		goto out;
+-	}
+ 
+-	notBefore = X509_get_notBefore(x509);
+-	if (!notBefore) {
+-		ok = false;
+-		goto out;
+-	}
+-	if (!X509_gmtime_adj(notBefore, 0)) {
+-		ok = false;
+-		goto out;
+-	}
++bool SelfSignedCertificate::generate(CertificateType certificateType, QString clientCertName, QString clientCertEmail,
++									 QSslCertificate &qscCert, QSslKey &qskKey) {
++	bool ok                    = true;
++	EVP_PKEY *pkey             = nullptr;
++	X509 *x509                 = nullptr;
++	X509_NAME *name            = nullptr;
++	ASN1_INTEGER *serialNumber = nullptr;
++	ASN1_TIME *notBefore       = nullptr;
++	ASN1_TIME *notAfter        = nullptr;
++	QString commonName;
++	bool isServerCert = certificateType == CertificateTypeServerCertificate;
+ 
+-	notAfter = X509_get_notAfter(x509);
+-	if (!notAfter) {
+-		ok = false;
+-		goto out;
+-	}
+-	if (!X509_gmtime_adj(notAfter, 60 * 60 * 24 * 365 * 20)) {
+-		ok = false;
+-		goto out;
+-	}
++	// In Qt 5.15, a class was added to wrap up the procedures of generating a self-signed certificate.
++	// See https://doc.qt.io/qt-5/qopcuax509certificatesigningrequest.html.
++	// We should consider migrating to this class after switching to Qt 5.15.
+ 
+-	if (X509_set_pubkey(x509, pkey) == 0) {
+-		ok = false;
+-		goto out;
+-	}
++	CHECK(pkey = generate_rsa_keypair());
+ 
+-	name = X509_get_subject_name(x509);
+-	if (!name) {
+-		ok = false;
+-		goto out;
+-	}
++	CHECK(x509 = X509_new());
++	CHECK(X509_set_version(x509, 2));
++	CHECK(serialNumber = X509_get_serialNumber(x509));
++	CHECK(ASN1_INTEGER_set(serialNumber, 1));
++	CHECK(notBefore = X509_get_notBefore(x509));
++	CHECK(X509_gmtime_adj(notBefore, 0));
++	CHECK(notAfter = X509_get_notAfter(x509));
++	CHECK(X509_gmtime_adj(notAfter, 60 * 60 * 24 * 365 * 20))
++	CHECK(X509_set_pubkey(x509, pkey));
++	CHECK(name = X509_get_subject_name(x509));
+ 
+ 	if (isServerCert) {
+ 		commonName = QLatin1String("Murmur Autogenerated Certificate v2");
+@@ -141,120 +117,63 @@ bool SelfSignedCertificate::generate(CertificateType certificateType, QString cl
+ 		}
+ 	}
+ 
+-	if (X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_UTF8,
+-								   reinterpret_cast< unsigned char * >(commonName.toUtf8().data()), -1, -1, 0)
+-		== 0) {
+-		ok = false;
+-		goto out;
+-	}
++	CHECK(X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_UTF8,
++									 reinterpret_cast< unsigned char * >(commonName.toUtf8().data()), -1, -1, 0));
+ 
+-	if (X509_set_issuer_name(x509, name) == 0) {
+-		ok = false;
+-		goto out;
+-	}
++	CHECK(X509_set_issuer_name(x509, name));
+ 
+-	if (add_ext(x509, NID_basic_constraints, SSL_STRING("critical,CA:FALSE")) == 0) {
+-		ok = false;
+-		goto out;
+-	}
++	CHECK(add_ext(x509, NID_basic_constraints, SSL_STRING("critical,CA:FALSE")));
+ 
+ 	if (isServerCert) {
+-		if (add_ext(x509, NID_ext_key_usage, SSL_STRING("serverAuth,clientAuth")) == 0) {
+-			ok = false;
+-			goto out;
+-		}
++		CHECK(add_ext(x509, NID_ext_key_usage, SSL_STRING("serverAuth,clientAuth")))
+ 	} else {
+-		if (add_ext(x509, NID_ext_key_usage, SSL_STRING("clientAuth")) == 0) {
+-			ok = false;
+-			goto out;
+-		}
++		CHECK(add_ext(x509, NID_ext_key_usage, SSL_STRING("clientAuth")));
+ 	}
+ 
+-	if (add_ext(x509, NID_subject_key_identifier, SSL_STRING("hash")) == 0) {
+-		ok = false;
+-		goto out;
+-	}
++	CHECK(add_ext(x509, NID_subject_key_identifier, SSL_STRING("hash")));
+ 
+ 	if (isServerCert) {
+-		if (add_ext(x509, NID_netscape_comment, SSL_STRING("Generated from murmur")) == 0) {
+-			ok = false;
+-			goto out;
+-		}
++		CHECK(add_ext(x509, NID_netscape_comment, SSL_STRING("Generated from murmur")));
+ 	} else {
+-		if (add_ext(x509, NID_netscape_comment, SSL_STRING("Generated by Mumble")) == 0) {
+-			ok = false;
+-			goto out;
+-		}
++		CHECK(add_ext(x509, NID_netscape_comment, SSL_STRING("Generated by Mumble")));
+ 	}
+ 
+ 	if (!isServerCert) {
+ 		if (!clientCertEmail.trimmed().isEmpty()) {
+-			if (add_ext(x509, NID_subject_alt_name,
+-						QString::fromLatin1("email:%1").arg(clientCertEmail).toUtf8().data())
+-				== 0) {
+-				ok = false;
+-				goto out;
+-			}
++			CHECK(add_ext(x509, NID_subject_alt_name,
++						  QString::fromLatin1("email:%1").arg(clientCertEmail).toUtf8().data()));
+ 		}
+ 	}
+ 
+-	if (X509_sign(x509, pkey, EVP_sha1()) == 0) {
+-		ok = false;
+-		goto out;
+-	}
++	CHECK(X509_sign(x509, pkey, EVP_sha1()));
+ 
+ 	{
+ 		QByteArray crt;
+ 		int len = i2d_X509(x509, nullptr);
+-		if (len <= 0) {
+-			ok = false;
+-			goto out;
+-		}
++		CHECK(len > 0);
+ 		crt.resize(len);
+ 
+ 		unsigned char *dptr = reinterpret_cast< unsigned char * >(crt.data());
+-		if (i2d_X509(x509, &dptr) != len) {
+-			ok = false;
+-			goto out;
+-		}
++		CHECK(i2d_X509(x509, &dptr) == len);
+ 
+ 		qscCert = QSslCertificate(crt, QSsl::Der);
+-		if (qscCert.isNull()) {
+-			ok = false;
+-			goto out;
+-		}
++		CHECK(!qscCert.isNull());
+ 	}
+ 
+ 	{
+ 		QByteArray key;
+ 		int len = i2d_PrivateKey(pkey, nullptr);
+-		if (len <= 0) {
+-			ok = false;
+-			goto out;
+-		}
++		CHECK(len > 0);
+ 		key.resize(len);
+ 
+ 		unsigned char *dptr = reinterpret_cast< unsigned char * >(key.data());
+-		if (i2d_PrivateKey(pkey, &dptr) != len) {
+-			ok = false;
+-			goto out;
+-		}
++		CHECK(i2d_PrivateKey(pkey, &dptr) == len);
+ 
+ 		qskKey = QSslKey(key, QSsl::Rsa, QSsl::Der);
+-		if (qskKey.isNull()) {
+-			ok = false;
+-			goto out;
+-		}
++		CHECK(!qskKey.isNull());
+ 	}
+ 
+ out:
+-	if (e) {
+-		BN_free(e);
+-	}
+-	// We only need to free the pkey pointer,
+-	// not the RSA pointer. We have assigned
+-	// our RSA key to pkey, and it will be freed
+-	// once we free pkey.
+ 	if (pkey) {
+ 		EVP_PKEY_free(pkey);
+ 	}
+diff --git a/src/SelfSignedCertificate.h b/src/SelfSignedCertificate.h
+index b85a8752b..7c5f59e9c 100644
+--- a/src/SelfSignedCertificate.h
++++ b/src/SelfSignedCertificate.h
+@@ -6,6 +6,10 @@
+ #ifndef MUMBLE_SELFSIGNEDCERTIFICATE_H_
+ #define MUMBLE_SELFSIGNEDCERTIFICATE_H_
+ 
++#include <openssl/evp.h>
++#include <openssl/rsa.h>
++#include <openssl/x509v3.h>
++
+ #include <QtCore/QString>
+ #include <QtNetwork/QSslCertificate>
+ #include <QtNetwork/QSslKey>
+@@ -16,6 +20,7 @@ class SelfSignedCertificate {
+ private:
+ 	static bool generate(CertificateType certificateType, QString clientCertName, QString clientCertEmail,
+ 						 QSslCertificate &qscCert, QSslKey &qskKey);
++	static EVP_PKEY *generate_rsa_keypair();
+ 
+ public:
+ 	static bool generateMumbleCertificate(QString name, QString email, QSslCertificate &qscCert, QSslKey &qskKey);
+diff --git a/src/crypto/CryptStateOCB2.cpp b/src/crypto/CryptStateOCB2.cpp
+index 2176d6488..640fdedac 100644
+--- a/src/crypto/CryptStateOCB2.cpp
++++ b/src/crypto/CryptStateOCB2.cpp
+@@ -30,7 +30,7 @@
+ #include <cstring>
+ #include <openssl/rand.h>
+ 
+-CryptStateOCB2::CryptStateOCB2() : CryptState() {
++CryptStateOCB2::CryptStateOCB2() : CryptState(), enc_ctx(EVP_CIPHER_CTX_new()), dec_ctx(EVP_CIPHER_CTX_new()) {
+ 	for (int i = 0; i < 0x100; i++)
+ 		decrypt_history[i] = 0;
+ 	memset(raw_key, 0, AES_KEY_SIZE_BYTES);
+@@ -38,6 +38,11 @@ CryptStateOCB2::CryptStateOCB2() : CryptState() {
+ 	memset(decrypt_iv, 0, AES_BLOCK_SIZE);
+ }
+ 
++CryptStateOCB2::~CryptStateOCB2() noexcept {
++	EVP_CIPHER_CTX_free(enc_ctx);
++	EVP_CIPHER_CTX_free(dec_ctx);
++}
++
+ bool CryptStateOCB2::isValid() const {
+ 	return bInit;
+ }
+@@ -46,8 +51,6 @@ void CryptStateOCB2::genKey() {
+ 	CryptographicRandom::fillBuffer(raw_key, AES_KEY_SIZE_BYTES);
+ 	CryptographicRandom::fillBuffer(encrypt_iv, AES_BLOCK_SIZE);
+ 	CryptographicRandom::fillBuffer(decrypt_iv, AES_BLOCK_SIZE);
+-	AES_set_encrypt_key(raw_key, AES_KEY_SIZE_BITS, &encrypt_key);
+-	AES_set_decrypt_key(raw_key, AES_KEY_SIZE_BITS, &decrypt_key);
+ 	bInit = true;
+ }
+ 
+@@ -56,8 +59,6 @@ bool CryptStateOCB2::setKey(const std::string &rkey, const std::string &eiv, con
+ 		memcpy(raw_key, rkey.data(), AES_KEY_SIZE_BYTES);
+ 		memcpy(encrypt_iv, eiv.data(), AES_BLOCK_SIZE);
+ 		memcpy(decrypt_iv, div.data(), AES_BLOCK_SIZE);
+-		AES_set_encrypt_key(raw_key, AES_KEY_SIZE_BITS, &encrypt_key);
+-		AES_set_decrypt_key(raw_key, AES_KEY_SIZE_BITS, &decrypt_key);
+ 		bInit = true;
+ 		return true;
+ 	}
+@@ -256,10 +257,24 @@ static void inline ZERO(keyblock &block) {
+ 		block[i] = 0;
+ }
+ 
+-#define AESencrypt(src, dst, key) \
+-	AES_encrypt(reinterpret_cast< const unsigned char * >(src), reinterpret_cast< unsigned char * >(dst), key);
+-#define AESdecrypt(src, dst, key) \
+-	AES_decrypt(reinterpret_cast< const unsigned char * >(src), reinterpret_cast< unsigned char * >(dst), key);
++#define AESencrypt(src, dst, key)                                                                 \
++	{                                                                                             \
++		int outlen = 0;                                                                           \
++		EVP_EncryptInit_ex(enc_ctx, EVP_aes_128_ecb(), NULL, key, NULL);                          \
++		EVP_CIPHER_CTX_set_padding(enc_ctx, 0);                                                   \
++		EVP_EncryptUpdate(enc_ctx, reinterpret_cast< unsigned char * >(dst), &outlen,             \
++						  reinterpret_cast< const unsigned char * >(src), AES_BLOCK_SIZE);        \
++		EVP_EncryptFinal_ex(enc_ctx, reinterpret_cast< unsigned char * >(dst + outlen), &outlen); \
++	}
++#define AESdecrypt(src, dst, key)                                                                 \
++	{                                                                                             \
++		int outlen = 0;                                                                           \
++		EVP_DecryptInit_ex(dec_ctx, EVP_aes_128_ecb(), NULL, key, NULL);                          \
++		EVP_CIPHER_CTX_set_padding(dec_ctx, 0);                                                   \
++		EVP_DecryptUpdate(dec_ctx, reinterpret_cast< unsigned char * >(dst), &outlen,             \
++						  reinterpret_cast< const unsigned char * >(src), AES_BLOCK_SIZE);        \
++		EVP_DecryptFinal_ex(dec_ctx, reinterpret_cast< unsigned char * >(dst + outlen), &outlen); \
++	}
+ 
+ bool CryptStateOCB2::ocb_encrypt(const unsigned char *plain, unsigned char *encrypted, unsigned int len,
+ 								 const unsigned char *nonce, unsigned char *tag, bool modifyPlainOnXEXStarAttack) {
+@@ -267,7 +282,7 @@ bool CryptStateOCB2::ocb_encrypt(const unsigned char *plain, unsigned char *encr
+ 	bool success = true;
+ 
+ 	// Initialize
+-	AESencrypt(nonce, delta, &encrypt_key);
++	AESencrypt(nonce, delta, raw_key);
+ 	ZERO(checksum);
+ 
+ 	while (len > AES_BLOCK_SIZE) {
+@@ -299,7 +314,7 @@ bool CryptStateOCB2::ocb_encrypt(const unsigned char *plain, unsigned char *encr
+ 		if (flipABit) {
+ 			*reinterpret_cast< unsigned char * >(tmp) ^= 1;
+ 		}
+-		AESencrypt(tmp, tmp, &encrypt_key);
++		AESencrypt(tmp, tmp, raw_key);
+ 		XOR(reinterpret_cast< subblock * >(encrypted), delta, tmp);
+ 		XOR(checksum, checksum, reinterpret_cast< const subblock * >(plain));
+ 		if (flipABit) {
+@@ -315,7 +330,7 @@ bool CryptStateOCB2::ocb_encrypt(const unsigned char *plain, unsigned char *encr
+ 	ZERO(tmp);
+ 	tmp[BLOCKSIZE - 1] = SWAPPED(len * 8);
+ 	XOR(tmp, tmp, delta);
+-	AESencrypt(tmp, pad, &encrypt_key);
++	AESencrypt(tmp, pad, raw_key);
+ 	memcpy(tmp, plain, len);
+ 	memcpy(reinterpret_cast< unsigned char * >(tmp) + len, reinterpret_cast< const unsigned char * >(pad) + len,
+ 		   AES_BLOCK_SIZE - len);
+@@ -325,7 +340,7 @@ bool CryptStateOCB2::ocb_encrypt(const unsigned char *plain, unsigned char *encr
+ 
+ 	S3(delta);
+ 	XOR(tmp, delta, checksum);
+-	AESencrypt(tmp, tag, &encrypt_key);
++	AESencrypt(tmp, tag, raw_key);
+ 
+ 	return success;
+ }
+@@ -336,13 +351,13 @@ bool CryptStateOCB2::ocb_decrypt(const unsigned char *encrypted, unsigned char *
+ 	bool success = true;
+ 
+ 	// Initialize
+-	AESencrypt(nonce, delta, &encrypt_key);
++	AESencrypt(nonce, delta, raw_key);
+ 	ZERO(checksum);
+ 
+ 	while (len > AES_BLOCK_SIZE) {
+ 		S2(delta);
+ 		XOR(tmp, delta, reinterpret_cast< const subblock * >(encrypted));
+-		AESdecrypt(tmp, tmp, &decrypt_key);
++		AESdecrypt(tmp, tmp, raw_key);
+ 		XOR(reinterpret_cast< subblock * >(plain), delta, tmp);
+ 		XOR(checksum, checksum, reinterpret_cast< const subblock * >(plain));
+ 		len -= AES_BLOCK_SIZE;
+@@ -354,7 +369,7 @@ bool CryptStateOCB2::ocb_decrypt(const unsigned char *encrypted, unsigned char *
+ 	ZERO(tmp);
+ 	tmp[BLOCKSIZE - 1] = SWAPPED(len * 8);
+ 	XOR(tmp, tmp, delta);
+-	AESencrypt(tmp, pad, &encrypt_key);
++	AESencrypt(tmp, pad, raw_key);
+ 	memset(tmp, 0, AES_BLOCK_SIZE);
+ 	memcpy(tmp, encrypted, len);
+ 	XOR(tmp, tmp, pad);
+@@ -372,7 +387,7 @@ bool CryptStateOCB2::ocb_decrypt(const unsigned char *encrypted, unsigned char *
+ 
+ 	S3(delta);
+ 	XOR(tmp, delta, checksum);
+-	AESencrypt(tmp, tag, &encrypt_key);
++	AESencrypt(tmp, tag, raw_key);
+ 
+ 	return success;
+ }
+@@ -381,5 +396,5 @@ bool CryptStateOCB2::ocb_decrypt(const unsigned char *encrypted, unsigned char *
+ #undef SHIFTBITS
+ #undef SWAPPED
+ #undef HIGHBIT
+-#undef AES_encrypt
+-#undef AES_decrypt
++#undef AESencrypt
++#undef AESdecrypt
+diff --git a/src/crypto/CryptStateOCB2.h b/src/crypto/CryptStateOCB2.h
+index 53d4b4b6a..cc3f1c0bc 100644
+--- a/src/crypto/CryptStateOCB2.h
++++ b/src/crypto/CryptStateOCB2.h
+@@ -8,8 +8,9 @@
+ 
+ #include "CryptState.h"
+ 
+-#include <openssl/aes.h>
++#include <openssl/evp.h>
+ 
++#define AES_BLOCK_SIZE 16
+ #define AES_KEY_SIZE_BITS 128
+ #define AES_KEY_SIZE_BYTES (AES_KEY_SIZE_BITS / 8)
+ 
+@@ -17,7 +18,7 @@
+ class CryptStateOCB2 : public CryptState {
+ public:
+ 	CryptStateOCB2();
+-	~CryptStateOCB2(){};
++	~CryptStateOCB2() noexcept override;
+ 
+ 	virtual bool isValid() const Q_DECL_OVERRIDE;
+ 	virtual void genKey() Q_DECL_OVERRIDE;
+@@ -43,8 +44,8 @@ private:
+ 	unsigned char decrypt_iv[AES_BLOCK_SIZE];
+ 	unsigned char decrypt_history[0x100];
+ 
+-	AES_KEY encrypt_key;
+-	AES_KEY decrypt_key;
++	EVP_CIPHER_CTX *enc_ctx;
++	EVP_CIPHER_CTX *dec_ctx;
+ };
+ 
+ 
+-- 
+2.37.1
+

--- a/patches/mumble/0001-BUILD-overlay-build-overlay-on-Linux-and-FreeBSD-wit.patch
+++ b/patches/mumble/0001-BUILD-overlay-build-overlay-on-Linux-and-FreeBSD-wit.patch
@@ -1,0 +1,68 @@
+From 1cf13e0cdee59873d1793260b52c02ccbb6654b5 Mon Sep 17 00:00:00 2001
+From: Carlo Castoldi <carlo.castoldi@outlook.com>
+Date: Fri, 18 Nov 2022 12:44:02 +0100
+Subject: [PATCH] BUILD(overlay): build overlay on Linux and FreeBSD without
+ client flag
+
+---
+ CMakeLists.txt     | 10 +++++++---
+ src/CMakeLists.txt |  3 ---
+ 2 files changed, 7 insertions(+), 6 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 472673c..2c0f9e2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -52,12 +52,14 @@ include(TargetArch)
+ 
+ option(tests "Build tests" OFF)
+ 
++option(client "Build the client (Mumble)" ON)
++option(server "Build the server (Murmur)" ON)
+ option(optimize "Build a heavily optimized version, specific to the machine it's being compiled on." OFF)
+ option(static "Build static binaries." OFF)
+ option(symbols "Build binaries in a way that allows easier debugging." OFF)
+ option(warnings-as-errors "All warnings are treated as errors." OFF)
+ 
+-option(overlay "Build overlay." ON)
++option(overlay "Build overlay." ${client})
+ option(packaging "Build package." OFF)
+ option(plugins "Build plugins." ON)
+ 
+@@ -133,7 +135,9 @@ add_compile_definitions(MUMBLE_TARGET_OS="${MUMBLE_TARGET_OS}")
+ 
+ set(CMAKE_UNITY_BUILD_BATCH_SIZE 40)
+ 
+-add_subdirectory(src)
++if(client OR server)
++	add_subdirectory(src)
++endif()
+ 
+ if(g15 AND WIN32)
+ 	add_subdirectory(g15helper)
+@@ -146,7 +150,7 @@ if(APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
+ 	message(STATUS "Disabling the overlay on ARM macOS")
+ endif()
+ 
+-if(overlay AND client)
++if(overlay)
+ 	if(WIN32)
+ 		add_subdirectory(overlay)
+ 	else()
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 9b6a0f0..ef3c7ba 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -5,9 +5,6 @@
+ 
+ set(PROTO_FILE "${CMAKE_CURRENT_SOURCE_DIR}/Mumble.proto")
+ 
+-option(client "Build the client (Mumble)" ON)
+-option(server "Build the server (Murmur)" ON)
+-
+ option(qssldiffiehellmanparameters "Build support for custom Diffie-Hellman parameters." ON)
+ 
+ option(zeroconf "Build support for zeroconf (mDNS/DNS-SD)." ON)
+-- 
+2.38.1
+

--- a/patches/mumble/0001-CHANGE-ipc-move-Socket-and-OverlayPipe-to-XDG_RUNTIM.patch
+++ b/patches/mumble/0001-CHANGE-ipc-move-Socket-and-OverlayPipe-to-XDG_RUNTIM.patch
@@ -1,0 +1,207 @@
+From b79a2c9f6a95280b4c1ba6c40e1f6e04bb4585a2 Mon Sep 17 00:00:00 2001
+From: Carlo Castoldi <carlo.castoldi@outlook.com>
+Date: Sun, 13 Nov 2022 22:36:02 +0100
+Subject: [PATCH] CHANGE(ipc): move Socket and OverlayPipe to
+ $XDG_RUNTIME_DIR/mumble/
+
+Moving MumbleSocket and MumbleOverlayPipe to a dedicated subdirectory keeps the runtime directory clean and allows flatpak applications to use the overlay by giving access only to Mumble's subdirectory.
+It also moves the default directory to /run/user/$UID/mumble/ when $XDG_RUNTIME_DIR is not set.
+
+Fixes #5951
+---
+ overlay_gl/CMakeLists.txt |  7 +++----
+ overlay_gl/overlay.c      | 30 +++++++++++++++++++++---------
+ src/mumble/Overlay.cpp    | 12 +++++++-----
+ src/mumble/SocketRPC.cpp  | 25 +++++++++++++++----------
+ src/tests/OverlayTest.cpp | 16 ++++++++++++++--
+ 5 files changed, 60 insertions(+), 30 deletions(-)
+
+diff --git a/overlay_gl/CMakeLists.txt b/overlay_gl/CMakeLists.txt
+index 4a0a2dc67..746d68e3d 100644
+--- a/overlay_gl/CMakeLists.txt
++++ b/overlay_gl/CMakeLists.txt
+@@ -31,10 +31,9 @@ if(NOT APPLE)
+ 			"-Wl,-z,lazy"
+ 	)
+ 
+-	set_target_properties(overlay_gl
+-		PROPERTIES
+-			COMPILE_DEFINITIONS
+-				"TARGET_UNIX"
++	target_compile_definitions(overlay_gl
++		PRIVATE
++			"TARGET_UNIX"
+ 	)
+ 
+ 	if(overlay-xcompile)
+diff --git a/overlay_gl/overlay.c b/overlay_gl/overlay.c
+index 54149268b..8ea1de7ac 100644
+--- a/overlay_gl/overlay.c
++++ b/overlay_gl/overlay.c
+@@ -147,6 +147,24 @@ static void newContext(Context *ctx) {
+ 	ctx->timeT             = clock();
+ 	ctx->frameCount        = 0;
+ 
++#ifdef __linux__
++	char *xdgRuntimeDir = getenv("XDG_RUNTIME_DIR");
++
++	if (xdgRuntimeDir != NULL) {
++		ctx->saName.sun_family = PF_UNIX;
++		strcpy(ctx->saName.sun_path, xdgRuntimeDir);
++		if(xdgRuntimeDir[(strlen(xdgRuntimeDir)-1)] != '/')
++			strcat(ctx->saName.sun_path, "/");
++		strcat(ctx->saName.sun_path, "mumble/MumbleOverlayPipe");
++	} else {
++		char uid[10];
++		sprintf(uid, "%d", getuid());
++		ctx->saName.sun_family = PF_UNIX;
++		strcpy(ctx->saName.sun_path, "/run/user/");
++		strcat(ctx->saName.sun_path, uid);
++		strcat(ctx->saName.sun_path, "/mumble/MumbleOverlayPipe");
++	}
++#else
+ 	char *home = getenv("HOME");
+ 	if (home == NULL) {
+ 		struct passwd *pwent = getpwuid(getuid());
+@@ -154,18 +172,12 @@ static void newContext(Context *ctx) {
+ 			home = pwent->pw_dir;
+ 		}
+ 	}
+-
+-	char *xdgRuntimeDir = getenv("XDG_RUNTIME_DIR");
+-
+-	if (xdgRuntimeDir != NULL) {
+-		ctx->saName.sun_family = PF_UNIX;
+-		strcpy(ctx->saName.sun_path, xdgRuntimeDir);
+-		strcat(ctx->saName.sun_path, "/MumbleOverlayPipe");
+-	} else if (home) {
++	if (home) {
+ 		ctx->saName.sun_family = PF_UNIX;
+ 		strcpy(ctx->saName.sun_path, home);
+-		strcat(ctx->saName.sun_path, "/.MumbleOverlayPipe");
++		strcat(ctx->saName.sun_path, "/MumbleOverlayPipe");
+ 	}
++#endif
+ 
+ 	ods("OpenGL Version %s, Vendor %s, Renderer %s, Shader %s", glGetString(GL_VERSION), glGetString(GL_VENDOR),
+ 		glGetString(GL_RENDERER), glGetString(GL_SHADING_LANGUAGE_VERSION));
+diff --git a/src/mumble/Overlay.cpp b/src/mumble/Overlay.cpp
+index 107867525..ed8c5f5d0 100644
+--- a/src/mumble/Overlay.cpp
++++ b/src/mumble/Overlay.cpp
+@@ -244,13 +244,15 @@ void Overlay::createPipe() {
+ #else
+ 	{
+ 		QString xdgRuntimePath = QProcessEnvironment::systemEnvironment().value(QLatin1String("XDG_RUNTIME_DIR"));
+-		QDir xdgRuntimeDir     = QDir(xdgRuntimePath);
+-
+-		if (!xdgRuntimePath.isNull() && xdgRuntimeDir.exists()) {
+-			pipepath = xdgRuntimeDir.absoluteFilePath(QLatin1String("MumbleOverlayPipe"));
++		QString mumbleRuntimePath;
++		if (!xdgRuntimePath.isNull()) {
++		    mumbleRuntimePath = QDir(xdgRuntimePath).absolutePath() + QLatin1String("/mumble/");
+ 		} else {
+-			pipepath = QDir::home().absoluteFilePath(QLatin1String(".MumbleOverlayPipe"));
++			mumbleRuntimePath = QLatin1String("/run/user/") + QString::number(getuid()) + QLatin1String("/mumble/");
+ 		}
++		QDir mumbleRuntimeDir = QDir(mumbleRuntimePath);
++		mumbleRuntimeDir.mkpath(".");
++		pipepath = mumbleRuntimeDir.absoluteFilePath(QLatin1String("MumbleOverlayPipe"));
+ 	}
+ 
+ 	{
+diff --git a/src/mumble/SocketRPC.cpp b/src/mumble/SocketRPC.cpp
+index 0aabc8b15..bf1bcb6c6 100644
+--- a/src/mumble/SocketRPC.cpp
++++ b/src/mumble/SocketRPC.cpp
+@@ -236,13 +236,15 @@ SocketRPC::SocketRPC(const QString &basename, QObject *p) : QObject(p) {
+ #else
+ 	{
+ 		QString xdgRuntimePath = QProcessEnvironment::systemEnvironment().value(QLatin1String("XDG_RUNTIME_DIR"));
+-		QDir xdgRuntimeDir     = QDir(xdgRuntimePath);
+-
+-		if (!xdgRuntimePath.isNull() && xdgRuntimeDir.exists()) {
+-			pipepath = xdgRuntimeDir.absoluteFilePath(basename + QLatin1String("Socket"));
++		QString mumbleRuntimePath;
++		if (!xdgRuntimePath.isNull()) {
++		    mumbleRuntimePath = QDir(xdgRuntimePath).absolutePath() + QLatin1String("/mumble/");
+ 		} else {
+-			pipepath = QDir::home().absoluteFilePath(QLatin1String(".") + basename + QLatin1String("Socket"));
++			mumbleRuntimePath = QLatin1String("/run/user/") + QString::number(getuid()) + QLatin1String("/mumble/");
+ 		}
++		QDir mumbleRuntimeDir = QDir(mumbleRuntimePath);
++		mumbleRuntimeDir.mkpath(".");
++		pipepath = mumbleRuntimeDir.absoluteFilePath(basename + QLatin1String("Socket"));
+ 	}
+ 
+ 	{
+@@ -280,13 +282,15 @@ bool SocketRPC::send(const QString &basename, const QString &request, const QMap
+ #else
+ 	{
+ 		QString xdgRuntimePath = QProcessEnvironment::systemEnvironment().value(QLatin1String("XDG_RUNTIME_DIR"));
+-		QDir xdgRuntimeDir     = QDir(xdgRuntimePath);
+-
+-		if (!xdgRuntimePath.isNull() && xdgRuntimeDir.exists()) {
+-			pipepath = xdgRuntimeDir.absoluteFilePath(basename + QLatin1String("Socket"));
++		QString mumbleRuntimePath;
++		if (!xdgRuntimePath.isNull()) {
++		    mumbleRuntimePath = QDir(xdgRuntimePath).absolutePath() + QLatin1String("/mumble/");
+ 		} else {
+-			pipepath = QDir::home().absoluteFilePath(QLatin1String(".") + basename + QLatin1String("Socket"));
++			mumbleRuntimePath = QLatin1String("/run/user/") + QString::number(getuid()) + QLatin1String("/mumble/");
+ 		}
++		QDir mumbleRuntimeDir = QDir(mumbleRuntimePath);
++		mumbleRuntimeDir.mkpath(".");
++		pipepath = mumbleRuntimeDir.absoluteFilePath(basename + QLatin1String("Socket"));
+ 	}
+ #endif
+ 
+@@ -325,3 +329,4 @@ bool SocketRPC::send(const QString &basename, const QString &request, const QMap
+ 
+ 	return QVariant(succ.text()).toBool();
+ }
++
+diff --git a/src/tests/OverlayTest.cpp b/src/tests/OverlayTest.cpp
+index a565d54e9..8d8e8e4a7 100644
+--- a/src/tests/OverlayTest.cpp
++++ b/src/tests/OverlayTest.cpp
+@@ -16,6 +16,7 @@
+ #	include "win.h"
+ #endif
+ 
++#include <unistd.h>
+ #include <QtCore>
+ #include <QtGui>
+ #include <QtNetwork>
+@@ -96,7 +97,18 @@ void OverlayWidget::paintEvent(QPaintEvent *) {
+ #ifdef Q_OS_WIN
+ 		qlsSocket->connectToServer(QLatin1String("MumbleOverlayPipe"));
+ #else
+-		qlsSocket->connectToServer(QDir::home().absoluteFilePath(QLatin1String(".MumbleOverlayPipe")));
++		QString xdgRuntimePath = QProcessEnvironment::systemEnvironment().value(QLatin1String("XDG_RUNTIME_DIR"));
++		QString mumbleRuntimePath;
++		if (!xdgRuntimePath.isNull()) {
++		    mumbleRuntimePath = QDir(xdgRuntimePath).absolutePath() + QLatin1String("/mumble/");
++		} else {
++			mumbleRuntimePath = QLatin1String("/run/user/") + QString::number(getuid()) + QLatin1String("/mumble/");
++		}
++		QDir mumbleRuntimeDir = QDir(mumbleRuntimePath);
++		mumbleRuntimeDir.mkpath(".");
++		QString pipepath = mumbleRuntimeDir.absoluteFilePath(QLatin1String("MumbleOverlayPipe"));
++		qWarning() << "connectToServer(" << pipepath << ")";
++		qlsSocket->connectToServer(pipepath);
+ #endif
+ 	}
+ 
+@@ -166,7 +178,7 @@ void OverlayWidget::disconnected() {
+ }
+ 
+ void OverlayWidget::error(QLocalSocket::LocalSocketError) {
+-	qWarning() << "error";
++	perror("error");
+ 	disconnected();
+ }
+ 
+-- 
+2.38.1
+

--- a/patches/mumble/0001-FIX-overlay-Implement-library-search-list-for-dlsym-.patch
+++ b/patches/mumble/0001-FIX-overlay-Implement-library-search-list-for-dlsym-.patch
@@ -1,0 +1,260 @@
+From 84535d893a6d233ca6618c0c6acaba782bb60a52 Mon Sep 17 00:00:00 2001
+From: Davide Beatrici <git@davidebeatrici.dev>
+Date: Sun, 6 Nov 2022 21:22:12 +0100
+Subject: [PATCH] FIX(overlay): Implement library search list for dlsym(), add
+ "libc.so.6" to it
+
+glibc 2.34 moved all functionality of various libraries into the main one.
+As a result, dlsym() is now exported by libc instead of libdl.
+
+This commit also makes the related code more robust.
+We now iterate through a common library name/path list, regardless of the OS.
+---
+ overlay_gl/init_unix.c | 212 ++++++++++++++++++++++-------------------
+ 1 file changed, 112 insertions(+), 100 deletions(-)
+
+diff --git a/overlay_gl/init_unix.c b/overlay_gl/init_unix.c
+index cf17acfe1..0cd0c1f58 100644
+--- a/overlay_gl/init_unix.c
++++ b/overlay_gl/init_unix.c
+@@ -162,125 +162,137 @@ __attribute__((visibility("default"))) void *dlsym(void *handle, const char *nam
+ }
+ 
+ static int find_odlsym() {
+-#if defined(__linux__)
+-	void *dl = dlopen("libdl.so.2", RTLD_LAZY);
+-	if (!dl) {
+-		ods("Failed to open libdl.so.2!");
+-		return -1;
+-	}
++	// clang-format off
++	const char *libs[] = {
++		"libc.so.6",
++		"libdl.so.2",
++		"/libexec/ld-elf.so.1"
++	};
++	// clang-format on
++
++	for (uint8_t libIdx = 0; libIdx < sizeof(libs) / sizeof(libs[0]); ++libIdx) {
++		const char *lib = libs[libIdx];
++		ods("Searching for dlsym() in \"%s\"...", lib);
++#ifdef RTLD_SELF
++		struct link_map *lm = NULL;
++		if (dlinfo(RTLD_SELF, RTLD_DI_LINKMAP, &lm) == -1) {
++			ods("Unable to acquire link_map: %s", dlerror());
++			return -1;
++		}
+ 
+-	struct link_map *lm = dl;
+-#elif defined(__FreeBSD__)
+-	struct link_map *lm = NULL;
+-	if (dlinfo(RTLD_SELF, RTLD_DI_LINKMAP, &lm) == -1) {
+-		ods("Unable to acquire link_map: %s", dlerror());
+-		return -1;
+-	}
++		while (lm) {
++			if (strcmp(lm->l_name, lib) == 0) {
++				break;
++			}
+ 
+-	while (lm) {
+-		if (strcmp(lm->l_name, "/libexec/ld-elf.so.1") == 0) {
+-			break;
++			lm = lm->l_next;
+ 		}
+ 
+-		lm = lm->l_next;
+-	}
++		if (!lm) {
++			ods("Failed to find \"%s\"!", lib);
++			continue;
++		}
++#else
++		void *dl = dlopen(lib, RTLD_LAZY);
++		if (!dl) {
++			ods("dlopen() failed: %s", dlerror());
++			continue;
++		}
+ 
+-	if (!lm) {
+-		ods("Failed to find ld-elf.so.1!");
+-		return -1;
+-	}
++		const struct link_map *lm = dl;
+ #endif
+-	bool hashTableGNU    = false;
+-	uintptr_t hashTable  = 0;
+-	const char *strTable = NULL;
+-	Elf_Sym *symTable    = NULL;
++		bool hashTableGNU    = false;
++		uintptr_t hashTable  = 0;
++		const char *strTable = NULL;
++		Elf_Sym *symTable    = NULL;
+ #if defined(__GLIBC__)
+-	const uintptr_t base = 0;
++		const uintptr_t base = 0;
+ #else
+-	const uintptr_t base = (uintptr_t) lm->l_addr;
++		const uintptr_t base      = (uintptr_t) lm->l_addr;
+ #endif
+-	for (const Elf_Dyn *dyn = lm->l_ld; dyn; ++dyn) {
+-		switch (dyn->d_tag) {
+-			case DT_GNU_HASH:
+-				if (!hashTable) {
+-					hashTable    = base + dyn->d_un.d_ptr;
+-					hashTableGNU = true;
+-				}
+-				break;
+-			case DT_HASH:
+-				if (!hashTable) {
+-					hashTable = base + dyn->d_un.d_ptr;
+-				}
+-				break;
+-			case DT_STRTAB:
+-				strTable = (const char *) (base + dyn->d_un.d_ptr);
+-				break;
+-			case DT_SYMTAB:
+-				symTable = (Elf_Sym *) (base + dyn->d_un.d_ptr);
++		for (const Elf_Dyn *dyn = lm->l_ld; dyn; ++dyn) {
++			switch (dyn->d_tag) {
++				case DT_GNU_HASH:
++					if (!hashTable) {
++						hashTable    = base + dyn->d_un.d_ptr;
++						hashTableGNU = true;
++					}
++					break;
++				case DT_HASH:
++					if (!hashTable) {
++						hashTable = base + dyn->d_un.d_ptr;
++					}
++					break;
++				case DT_STRTAB:
++					strTable = (const char *) (base + dyn->d_un.d_ptr);
++					break;
++				case DT_SYMTAB:
++					symTable = (Elf_Sym *) (base + dyn->d_un.d_ptr);
++					break;
++			}
++
++			if (hashTable && strTable && symTable) {
+ 				break;
++			}
+ 		}
+ 
+-		if (hashTable && strTable && symTable) {
+-			break;
+-		}
+-	}
++		ods("hashTable: 0x%" PRIxPTR ", strTable: %p, symTable: %p", hashTable, strTable, symTable);
+ 
+-	ods("hashTable: 0x%" PRIxPTR ", strTable: %p, symTable: %p", hashTable, strTable, symTable);
++		if (!hashTable || !strTable || !symTable) {
++			continue;
++		}
+ 
+-	if (!hashTable || !strTable || !symTable) {
+-		return -1;
+-	}
++		if (!hashTableGNU) {
++			ods("Using DT_HASH");
++			// Hash table pseudo-struct:
++			// uint32_t nBucket;
++			// uint32_t nChain;
++			// uint32_t bucket[nBucket];
++			// uint32_t chain[nChain];
++			const uint32_t nChain = ((uint32_t *) hashTable)[1];
++
++			for (uint32_t i = 0; i < nChain; ++i) {
++				if (ELF_ST_TYPE(symTable[i].st_info) != STT_FUNC) {
++					continue;
++				}
+ 
+-	if (!hashTableGNU) {
+-		ods("Using DT_HASH");
+-		// Hash table pseudo-struct:
+-		// uint32_t nBucket;
+-		// uint32_t nChain;
+-		// uint32_t bucket[nBucket];
+-		// uint32_t chain[nChain];
+-		const uint32_t nChain = ((uint32_t *) hashTable)[1];
+-
+-		for (uint32_t i = 0; i < nChain; ++i) {
+-			if (ELF_ST_TYPE(symTable[i].st_info) != STT_FUNC) {
+-				continue;
++				if (strcmp(strTable + symTable[i].st_name, "dlsym") == 0) {
++					odlsym = (void *) lm->l_addr + symTable[i].st_value;
++					break;
++				}
+ 			}
++		} else {
++			ods("Using DT_GNU_HASH");
++			// Hash table pseudo-struct:
++			// uint32_t  nBucket;
++			// uint32_t  symOffset;
++			// uint32_t  nBloom;
++			// uint32_t  bloomShift;
++			// uintptr_t blooms[nBloom];
++			// uint32_t  buckets[nBucket];
++			// uint32_t  chain[];
++			uint32_t *hashStruct = (uint32_t *) hashTable;
++
++			const uint32_t nBucket   = hashStruct[0];
++			const uint32_t symOffset = hashStruct[1];
++			const uint32_t nBloom    = hashStruct[2];
++			const uintptr_t *bloom   = (uintptr_t *) &hashStruct[4];
++			const uint32_t *buckets  = (uint32_t *) &bloom[nBloom];
++			const uint32_t *chain    = &buckets[nBucket];
++
++			for (uint32_t i = 0; i < nBucket; ++i) {
++				uint32_t symIndex = buckets[i];
++				if (symIndex < symOffset) {
++					continue;
++				}
+ 
+-			if (strcmp(strTable + symTable[i].st_name, "dlsym") == 0) {
+-				odlsym = (void *) lm->l_addr + symTable[i].st_value;
+-				break;
++				do {
++					if (strcmp(strTable + symTable[symIndex].st_name, "dlsym") == 0) {
++						odlsym = (void *) lm->l_addr + symTable[symIndex].st_value;
++					}
++				} while (!odlsym && !(chain[symIndex++ - symOffset] & 1));
+ 			}
+ 		}
+-	} else {
+-		ods("Using DT_GNU_HASH");
+-		// Hash table pseudo-struct:
+-		// uint32_t  nBucket;
+-		// uint32_t  symOffset;
+-		// uint32_t  nBloom;
+-		// uint32_t  bloomShift;
+-		// uintptr_t blooms[nBloom];
+-		// uint32_t  buckets[nBucket];
+-		// uint32_t  chain[];
+-		uint32_t *hashStruct = (uint32_t *) hashTable;
+-
+-		const uint32_t nBucket   = hashStruct[0];
+-		const uint32_t symOffset = hashStruct[1];
+-		const uint32_t nBloom    = hashStruct[2];
+-		const uintptr_t *bloom   = (uintptr_t *) &hashStruct[4];
+-		const uint32_t *buckets  = (uint32_t *) &bloom[nBloom];
+-		const uint32_t *chain    = &buckets[nBucket];
+-
+-		for (uint32_t i = 0; i < nBucket; ++i) {
+-			uint32_t symIndex = buckets[i];
+-			if (symIndex < symOffset) {
+-				continue;
+-			}
+-
+-			do {
+-				if (strcmp(strTable + symTable[symIndex].st_name, "dlsym") == 0) {
+-					odlsym = (void *) lm->l_addr + symTable[symIndex].st_value;
+-				}
+-			} while (!odlsym && !(chain[symIndex++ - symOffset] & 1));
+-		}
+ 	}
+ 
+ 	if (!odlsym) {
+-- 
+2.38.1
+


### PR DESCRIPTION
- Switch to tagged release, backport openssl3 patch
- Backport patch allowing to build overlay only
- Add patch moving comm socket to mumble/ subdir
- Build mumble for each architecture as native one, disabling xcompile

I didn't actually test this, beacause I'm unfamiliar with Mumble and even less so with its overlay, but the build looks legit (effectively the same approach to flatpak multiarch extensions is used in MangoHud flatpak).

Enabling the overlay should work as `LD_PRELOAD=/app/utils/MumbleOverlay/\$LIB/mumble/libmumbleoverlay.so`. Note the `$LIB` - it's a placeholder for the dynamic library loader that expands into architecture-specific subpath (`lib/x86_64-linux-gnu` or `lib/i386-linux-gnu` in case of flatpak) and allows us to use the same path in `LD_PRELOAD` for both architectures.